### PR TITLE
Refactor method to getting areas

### DIFF
--- a/src/main/java/org/niord/proxy/rest/MessageService.java
+++ b/src/main/java/org/niord/proxy/rest/MessageService.java
@@ -324,7 +324,7 @@ public class MessageService extends AbstractNiordService {
 
                     if (area != null) {
                         this.areaRoots.add(rootArea.setArea(area));
-                        log.info("Add new area to root: " + area.getMrn() + ", id:" + area.getId());
+                        log.info("Added new area to root: " + area.getMrn() + ", id:" + area.getId());
                     }
                 }
             }

--- a/src/main/java/org/niord/proxy/rest/MessageService.java
+++ b/src/main/java/org/niord/proxy/rest/MessageService.java
@@ -311,23 +311,22 @@ public class MessageService extends AbstractNiordService {
      */
     @Schedule(second = "12", minute = "*/3", hour = "*")
     public void periodicFetchData() {
-
         // Load all area roots defined by the settings - once...
-        if (this.areaRoots.isEmpty()) {
-            List<RootArea> areaRoots = new ArrayList<>();
+        if (this.areaRoots != null) {
             for (RootArea rootArea : settings.getRootAreas()) {
+                if (!this.areaRoots.stream().anyMatch(a -> a.getMrn().equals(rootArea))) {
 
-                // Fetch the area from the server
-                AreaVo area = executeNiordJsonRequest(
-                        getAreaUrl(rootArea.getAreaId()),
-                        json -> new ObjectMapper().readValue(json, AreaVo.class));
+                    // Fetch the area from the server
+                    AreaVo area = executeNiordJsonRequest(
+                            getAreaUrl(rootArea.getAreaId()),
+                            json -> new ObjectMapper().readValue(json, AreaVo.class));
 
-                if (area != null) {
-                    areaRoots.add(rootArea.setArea(area));
+                    if (area != null) {
+                        this.areaRoots.add(rootArea.setArea(area));
+                        log.info("Add new area root: " + area.getId());
+                    }
                 }
             }
-            this.areaRoots = areaRoots;
-            log.info("Loaded area roots: " + areaRoots);
         }
 
 

--- a/src/main/java/org/niord/proxy/rest/MessageService.java
+++ b/src/main/java/org/niord/proxy/rest/MessageService.java
@@ -314,7 +314,8 @@ public class MessageService extends AbstractNiordService {
         // Load all area roots defined by the settings - once...
         if (this.areaRoots != null) {
             for (RootArea rootArea : settings.getRootAreas()) {
-                if (!this.areaRoots.stream().anyMatch(a -> a.getMrn().equals(rootArea))) {
+                if (this.areaRoots.stream().noneMatch(a -> a.getMrn().equals(rootArea.getAreaId()))) {
+                    log.info("Try to fetch area from server: " + rootArea.getAreaId());
 
                     // Fetch the area from the server
                     AreaVo area = executeNiordJsonRequest(
@@ -323,12 +324,11 @@ public class MessageService extends AbstractNiordService {
 
                     if (area != null) {
                         this.areaRoots.add(rootArea.setArea(area));
-                        log.info("Add new area root: " + area.getId());
+                        log.info("Add new area to root: " + area.getMrn() + ", id:" + area.getId());
                     }
                 }
             }
         }
-
 
         // Load all active messages
         List<MessageVo> messages = executeNiordJsonRequest(


### PR DESCRIPTION
Change the method to retry calls for areas that are not fetched yet. It solves a problem with fetching all the areas at system startup. If some areas cannot be loaded they will be retried with next execution of method